### PR TITLE
Grey out buttons when no stream around

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,13 +80,11 @@ export default function App() {
               movement={movement}
               others={users}
             />
-            {stream && (
-              <ButtonArea
-                stream={stream}
-                audioEnabled={audioEnabled}
-                videoEnabled={videoEnabled}
-              />
-            )}
+            <ButtonArea
+              stream={stream}
+              audioEnabled={audioEnabled}
+              videoEnabled={videoEnabled}
+            />
           </div>
         </>
       )}

--- a/src/ButtonArea.tsx
+++ b/src/ButtonArea.tsx
@@ -9,7 +9,7 @@ import {
 import { setEnabled } from "userMedia/mediaStream";
 
 interface Props {
-  stream: MediaStream;
+  stream: MediaStream | null;
   audioEnabled: boolean;
   videoEnabled: boolean;
 }
@@ -28,7 +28,8 @@ export const ButtonArea: FC<Props> = ({
           shape="round"
           icon={<CloseSquareOutlined />}
           size="large"
-          onClick={() => setEnabled("video", false, stream)}
+          disabled={!stream}
+          onClick={() => stream && setEnabled("video", false, stream)}
         />
       ) : (
         <Button
@@ -37,7 +38,8 @@ export const ButtonArea: FC<Props> = ({
           shape="round"
           icon={<VideoCameraOutlined />}
           size="large"
-          onClick={() => setEnabled("video", true, stream)}
+          disabled={!stream}
+          onClick={() => stream && setEnabled("video", true, stream)}
         />
       )}
       {audioEnabled ? (
@@ -47,7 +49,8 @@ export const ButtonArea: FC<Props> = ({
           shape="round"
           icon={<AudioMutedOutlined />}
           size="large"
-          onClick={() => setEnabled("audio", false, stream)}
+          disabled={!stream}
+          onClick={() => stream && setEnabled("audio", false, stream)}
         />
       ) : (
         <Button
@@ -56,7 +59,8 @@ export const ButtonArea: FC<Props> = ({
           shape="round"
           icon={<AudioOutlined />}
           size="large"
-          onClick={() => setEnabled("audio", true, stream)}
+          disabled={!stream}
+          onClick={() => stream && setEnabled("audio", true, stream)}
         />
       )}
     </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -65,7 +65,6 @@ body {
   border-radius: 15px;
   border: 2px solid #333029;
   display: inline-block;
-  cursor: pointer;
   color: #505739;
   font-size: 14px;
   font-weight: bold;
@@ -74,7 +73,12 @@ body {
   outline: none;
 }
 
-.Button:hover {
+.Button:hover:enabled {
   background: linear-gradient(to bottom, #ccc2a6 5%, #eae0c2 100%);
   background-color: #ccc2a6;
+  cursor: pointer;
+}
+
+.Button:disabled {
+  opacity: 40%;
 }


### PR DESCRIPTION
Currently the camera/microphone buttons are missing if no media stream is around (e.g. no permissions). With this change they do appear but greyed out.